### PR TITLE
Add prompt builder using FAISS search

### DIFF
--- a/pdf_faiss_index.py
+++ b/pdf_faiss_index.py
@@ -64,6 +64,20 @@ def search_index(
     return results
 
 
+def build_query_prompt(
+    user_query: str,
+    index: faiss.Index,
+    chunks: List[str],
+    model: SentenceTransformer,
+    top_k: int = 3,
+) -> str:
+    """Return retrieved context and user query as a single prompt."""
+
+    results = search_index(user_query, index, chunks, model, top_k)
+    context = "\n".join(text for text, _ in results)
+    return f"{context}\n\n{user_query}"
+
+
 if __name__ == "__main__":
     import argparse
 


### PR DESCRIPTION
## Summary
- support retrieving Basel PDF context
- add `build_query_prompt` to combine text retrieval with user query

## Testing
- `python -m py_compile pdf_faiss_index.py`


------
https://chatgpt.com/codex/tasks/task_e_6845cd6b350883329d93dba6c55cc9a5