### PR TITLE
Drop deprecated punkt_tab download

### DIFF
--- a/rag_lora_testgen/pdf_reader.py
+++ b/rag_lora_testgen/pdf_reader.py
@@ -10,7 +10,6 @@ from nltk.tokenize import sent_tokenize, word_tokenize
 def load_pdf_chunks(pdf_path: str, chunk_size: int = 500) -> list[str]:
     """Read ``pdf_path`` and split text into roughly ``chunk_size`` token chunks."""
     nltk.download("punkt", quiet=True)
-    nltk.download("punkt_tab", quiet=True)
 
     text_parts: list[str] = []
     with pdfplumber.open(pdf_path) as pdf:

--- a/rwa_pdf_loader.py
+++ b/rwa_pdf_loader.py
@@ -6,7 +6,6 @@ from nltk.tokenize import sent_tokenize, word_tokenize
 def load_basel_summary_chunks(pdf_path: str = "RWA_docs/Basel_summary.pdf", chunk_size: int = 500) -> list[str]:
     """Read Basel_summary.pdf and split text into ~``chunk_size`` token chunks."""
     nltk.download("punkt", quiet=True)
-    nltk.download("punkt_tab", quiet=True)
 
     text_parts = []
     with pdfplumber.open(pdf_path) as pdf:


### PR DESCRIPTION
## Summary
- remove `nltk.download("punkt_tab")` from pdf loaders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471056ef388332b639955a50e12fe0