### PR TITLE
Add simple pipeline script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ Basel III requires banks to maintain at least 4.5% Common Equity Tier 1 capital.
 ```
 
 Adapter path, base model ID and index files can be customised via command line options.
+
+## End-to-End Pipeline
+
+Run all steps (training, indexing and inference) in one go with `run_pipeline.sh`:
+
+```bash
+./run_pipeline.sh "What are the Basel III capital requirements?"
+```
+
+The script first trains LoRA adapters, builds the FAISS index and finally runs `demo_cli.py` with RAG enabled.

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Train LoRA adapters
+python lora_training_script.py
+
+# Build FAISS index from the Basel summary PDF
+python pdf_faiss_index.py --build
+
+# Run the demo with retrieval augmented generation
+python demo_cli.py "$1" --use-rag


### PR DESCRIPTION
## Summary
- add `run_pipeline.sh` for end-to-end training, index building and inference
- document pipeline usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471058ce7c8332a0b202d4ec006113